### PR TITLE
[wip] Add /logs-queries/list endpoint and paginated helper method

### DIFF
--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -44,3 +44,4 @@ from datadog.api.roles import Roles
 from datadog.api.permissions import Permissions
 from datadog.api.service_level_objectives import ServiceLevelObjective
 from datadog.api.synthetics import Synthetics
+from datadog.api.logs_queries import LogsQueries

--- a/datadog/api/logs_queries.py
+++ b/datadog/api/logs_queries.py
@@ -1,0 +1,51 @@
+from datadog.api.resources import ActionAPIResource
+
+class LogsQueries(ActionAPIResource):
+    """
+    A wrapper around LogsQueries HTTP API.
+    """
+    _resource_name = 'logs-queries'
+
+    @classmethod
+    def list(cls, **body):
+        """
+        Retrieve a list of logs
+
+        :returns: Dictionary representing the API's JSON response
+        """
+
+        return super(LogsQueries, cls)._trigger_class_action('POST', 'list', **body)
+
+    @classmethod
+    def list_all(cls, **body):
+        """
+        Retrieve a list of paginated logs
+
+        :returns: Array representing the API's JSON response concatenated together
+        """
+
+        request_body = body
+        storage = []
+        previous_id = 0
+
+        if "startAt" not in request_body:
+            request_body["startAt"] = None
+
+        while previous_id != request_body["startAt"]:
+            previous_id = request_body["startAt"]
+            result = super(LogsQueries, cls)._trigger_class_action('POST', 'list', **request_body)
+
+            if len(result["logs"]) == 0:
+                break
+
+            if "nextLogId" in result:
+                request_body["startAt"] = result["nextLogId"]
+            else:
+                request_body["startAt"] = None
+            
+            storage = storage + result["logs"]
+
+            if request_body["startAt"] is None:
+                break
+
+        return storage


### PR DESCRIPTION
## Summary

This Pull Request adds and endpoint for `logs-queries/list` following the guide listed here:

`https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#adding-new-api-endpoints`

It adds `POST /logs-queries/list`  Datadog API endpoints documented here: `https://docs.datadoghq.com/api/?lang=bash#get-a-list-of-logs` ,  

As well as a `list_all()` helper method to retrieve logs via paginated response, following the documentation here: `https://docs.datadoghq.com/logs/guide/collect-multiple-logs-with-pagination/#overview`

## Todo

- define pagination rate limiting behavior and error handling
- define error handling on paginated request
- add unit test
- update documentation and provide sample usage
